### PR TITLE
Not monitoring characterData

### DIFF
--- a/app/script.js
+++ b/app/script.js
@@ -131,7 +131,7 @@ window.onload = () => {
 	observer.observe(document.body, {
 		attributes: true,
 		childList: true,
-		characterData: true,
+		characterData: false,
 		subtree: true
 	});
 }


### PR DESCRIPTION
Chromium (more detailed, version 72.0.3626.96) is repeatedly showing me such log (somehow strange that Firefox 66 doesn't):
```
app.js:1 Uncaught TypeError: e.getElementsByTagName is not a function
    at o (app.js:1)
    at app.js:1
    at Array.forEach (<anonymous>)
    at MutationObserver.<anonymous> (app.js:1)
```

It seems that trying to invoke a `getElementsByTagName` from `characterData` is causing problems on Chromium and we don't seem to need monitoring it.